### PR TITLE
chore: reorder private constructor for consistency and clarity

### DIFF
--- a/src/ComicGeek.Domain/Comics/ComicSeries.cs
+++ b/src/ComicGeek.Domain/Comics/ComicSeries.cs
@@ -1,5 +1,4 @@
 ﻿using ComicGeek.Domain.Common;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ComicGeek.Domain.Comics;
@@ -12,12 +11,12 @@ public sealed class ComicSeries : Entity
 
     public IReadOnlyCollection<Comic> Comics => _comics;
 
-    private ComicSeries() { }
-
     /// <summary>
     /// Entity Framework Constructor
     /// </summary>
     [ExcludeFromCodeCoverage]
+    private ComicSeries() { }
+
     private ComicSeries(string name)
     {
         Name = Guard.Against


### PR DESCRIPTION
This pull request includes a minor change to the `ComicSeries` class in the `ComicGeek.Domain/Comics` directory. The change reorders the `private ComicSeries()` constructor to follow the `ExcludeFromCodeCoverage` attribute.

Codebase simplification:

* [`src/ComicGeek.Domain/Comics/ComicSeries.cs`](diffhunk://#diff-9197d602f28557003919213b877990c9048bb5f7df56cd4b21a7ce4b9a7ee6d5L15-R19): Moved the `private ComicSeries()` constructor to immediately follow the `ExcludeFromCodeCoverage` attribute.